### PR TITLE
[Proposal] Sync links list across tooling

### DIFF
--- a/scripts/cda-tracker/src/cda-tracker.js
+++ b/scripts/cda-tracker/src/cda-tracker.js
@@ -2,10 +2,15 @@
 (function() {
     function cdaTracker(config) {
       var defaultDomains = [
-        /(.*\.)?microsoft\.com$/,
-        /(.*\.)?msdn\.com$/,
-        /(.*\.)?visualstudio\.com$/,
-        "www.microsoftevents.com"
+        /(.*\.)?azure\.microsoft\.com$/,
+        /(.*\.)?blogs\.msdn\.microsoft.com$/,
+        /(.*\.)?channel9\.msdn\.com$/,
+        /(.*\.)?code\.visualstudio\.com$/,
+        /(.*\.)?cloudblogs\.microsoft\.com$/,
+        /(.*\.)?devblogs\.microsoft\.com$/,
+        /(.*\.)?docs\.microsoft\.com$/,
+        /(.*\.)?marketplace\.visualstudio\.com$/,
+        /(.*\.)?techcommunity\.microsoft\.com$/
       ];
     
       var domains = config.domains;


### PR DESCRIPTION
As described in [this issue](https://github.com/sinedied/cxa-track/issues/2), the CxA CLI by @sinedied is using a different list of links than this tool.

I got the "official" list from the CxA tracking plan document which should be right, so the CxA CLI already has the correct list, this PR syncs both tools to avoid miscommunication. 