### PR TITLE
Add "Keep Locale" property

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# advocate-linkers - developer's guide
+
+## Browser extension
+
+The code for the browser (Chrome) extenstion is under the [extension](/extension) folder. It's an AngularJS (version 1.7) app. 
+
+To run the extension locally: 
+1. Fork and clone the repo. 
+2. Go to the extensions manager in your browser - edge://extensions/ or chrome://extensions/. 
+3. Turn on Developer mode.
+4. Click on "Load unpacked".
+5. Select the [extension](/extension) folder in the project.
+
+The extension is available in your browser. Hit the refresh icon whenever you make changes to the files. 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,26 @@
 # advocate-linkers
 
+## Browser Extension
+Get the [WT'ify browser extension](https://chrome.google.com/webstore/detail/wtify/hemgoconacbmdiefpokgaodmmgidfopc) from the Chrome Web Store. 
+
+### Edge 
+The extension is available through the link above also for Edge. You must allow extensions from other stores first in the [extension manager](edge://extensions).
+
+### InPrivate / Incognito
+After installing WT'ify, go to the extension details and allow in InPrivate (Edge) / incognito (Chrome).
+
+### Usage
+When on a page you want to link to, instead of copying the URL from the address bar, click on the WT icon.
+ 
+![image](https://user-images.githubusercontent.com/4953875/117641805-e0c9fd00-b186-11eb-88b8-4bbc861f2e27.png)
+
+The URL is taken from the address bar. You can change it here. 
+Enter your details and Advocacy DevOps Item (ADO) ID. 
+
+*New Feature:* If you want to keep the locale code in the URL switch on ‘Keep Locale’.
+
+The settings are kept in the browser’s storage so that you don’t need to re-enter the details for every link!
+
 ## Web Application
 
 [![Build Status](https://dev.azure.com/shayneboyer/social-linker/_apis/build/status/spboyer.advocate-linkers?branchName=master)](https://dev.azure.com/shayneboyer/social-linker/_build/latest?definitionId=12&branchName=master&WT.mc_id=advocatelinkers-github-shboyer)

--- a/area-paths.json
+++ b/area-paths.json
@@ -11,7 +11,7 @@
 "iot",
 "java",
 "javascript",
-"m365 ",
+"m365",
 "mobile",
 "modinfra",
 "modops",

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -40,14 +40,22 @@
     <section>
       <div>
         <label for="" class="label">URL Configuration</label>
-        <div class="field">
-          <div class="control">
-            <label class="label">Area Path</label>
-            <select class="select" ng-model="config.values.areaPath" ng-change="saveConfiguration()">
-              <option ng-repeat="areaPath in areaPaths">{{areaPath}}</option>
-            </select>
-            <!-- <input ng-model="config.values.areaPath" class="input card-footer-item" type="text"
-              ng-blur="saveConfiguration()" /> -->
+        <div class="columns">
+          <div class="column field">
+            <div class="control">
+              <label class="label">Area Path</label>
+              <div class="select">
+                <select class="select" ng-model="config.values.areaPath" ng-change="saveConfiguration()">
+                  <option ng-repeat="areaPath in areaPaths">{{areaPath}}</option>
+                </select>
+              </div>
+            </div>
+          </div>
+          <div class="column field">
+            <div class="control">
+              <label class="label">Keep Locale</label>
+              <wt-switch checked="config.values.keepLocale" wt-change="changeLocaleConfig()" ng-mouseenter="logValue()"></wt-switch>
+            </div>
           </div>
         </div>
         <div class="field">

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -43,7 +43,7 @@
         <div class="field">
           <div class="control">
             <label class="label">Area Path</label>
-            <select class="select" ng-model="config.values.areaPath">
+            <select class="select" ng-model="config.values.areaPath" ng-change="saveConfiguration()">
               <option ng-repeat="areaPath in areaPaths">{{areaPath}}</option>
             </select>
             <!-- <input ng-model="config.values.areaPath" class="input card-footer-item" type="text"

--- a/extension/style.css
+++ b/extension/style.css
@@ -1,6 +1,5 @@
 body {
   width: 400px;
-  font-family: 
 }
 
 .status {
@@ -18,4 +17,71 @@ body {
 
 #tabs-with-content .tab-content.is-active {
   display: block;
+}
+
+.columns {
+  display: flex;
+}
+
+/* The switch - the box around the slider */
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 60px;
+  height: 34px;
+}
+
+/* Hide default HTML checkbox */
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+/* The slider */
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #dbdbdb;
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 30px;
+  width: 30px;
+  left: 2px;
+  bottom: 2px;
+  background-color: white;
+  -webkit-transition: .4s;
+  transition: .4s;
+}
+
+input:checked + .slider {
+  background-color: #2196F3;
+}
+
+input:focus + .slider {
+  box-shadow: 0 0 1px #2196F3;
+}
+
+input:checked + .slider:before {
+  -webkit-transform: translateX(26px);
+  -ms-transform: translateX(26px);
+  transform: translateX(26px);
+}
+
+/* Rounded sliders */
+.slider.round {
+  border-radius: 34px;
+}
+
+.slider.round:before {
+  border-radius: 50%;
 }


### PR DESCRIPTION
Due to demand, added a switch to keep the locale code from the original link. 
The property is saved like the other configurations.
Default value is false (not keeping the locale code).

Also fixed 2 bugs: 
- Save the configuration of the area path
- Removed space in area path "m365" which caused broken links.
