### PR TITLE
remove cd.ms shortener

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "WT'ify",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "description": "Constructs links to conform to the WebTrends tracking standard",
   "browser_action": {
     "default_popup": "popup.html",

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -31,11 +31,6 @@
           Track
         </button>
       </p>
-      <p class="control">
-        <button class="button is-info" ng-click="shortenUrl()">
-          Shorten
-        </button>
-      </p>
     </div>
     <section>
       <div>


### PR DESCRIPTION
Brian K left MSFT and the cd.ms shortener died with his account. A lot of people were using it. Removing it from the extension and I've published an updated version to the Chrome Web Store.